### PR TITLE
docs: add implementation plan and update readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.DS_Store
+.env
+
+# Build outputs
+app/dist
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,38 @@
+# HerWaypoint MVP Implementation Plan
+
+This document outlines an incremental path to build the full HerWaypoint MVP described in the specification.
+
+## 1. Repository Bootstrapping
+- [ ] Initialize TypeScript monorepo layout matching required file tree.
+- [ ] Add root `package.json` with scripts for dev, build, deploy, test, lint, and seed.
+- [ ] Configure eslint/prettier and basic `wrangler.toml` targeting Pages + KV.
+- [ ] Commit initial scaffolding.
+
+## 2. Server Foundations
+- [ ] Implement `_worker.ts` to serve static assets and route `/api/*` to server handler.
+- [ ] Create server modules (`kv.ts`, `session.ts`, `http.ts`, etc.) with placeholders.
+- [ ] Define Zod schemas in `src/server/schemas.ts` mirroring KV data model.
+
+## 3. Frontend Skeleton
+- [ ] Scaffold Vite + React app in `/app` with routes and minimal styling.
+- [ ] Implement `lib/api.ts` wrappers and basic state management.
+
+## 4. Core Features
+- [ ] Waitlist form storing emails in KV.
+- [ ] Traveler profile quiz and persistence.
+- [ ] Experience feed with TrustBadge and filters.
+- [ ] Experience detail page with reservation intent flow.
+- [ ] AI endpoints (`/api/ai/ask`, `/api/recommendations`) and TrustScore logic.
+
+## 5. Seeds, Tests & CI
+- [ ] Provide JSON seed data and endpoints guarded by `SEED_ENABLED`.
+- [ ] Implement unit tests (Vitest) for trust score and validators.
+- [ ] Add Playwright smoke test covering happy path.
+- [ ] Configure GitHub Actions for lint, unit tests, and deployment.
+
+## 6. Documentation & Polish
+- [ ] Expand `README.md` with setup, seeding, testing, and deployment instructions.
+- [ ] Ensure mobile layout has no horizontal scroll and passes accessibility basics.
+
+Tracking these tasks in issues or a project board will make the build more manageable. Each step should be accompanied by commits and pull requests with passing tests.
+

--- a/README.md
+++ b/README.md
@@ -22,20 +22,17 @@ HerWaypoint is an AI-powered travel concierge that connects solo female traveler
 | Launch | 11–12 | Soft launch, content marketing, feedback loop |
 
 ## Tech Stack (MVP)
-- **Frontend**: Next.js (deployed on Cloudflare Pages)
-- **Backend / API**: Cloudflare Workers
-- **Database**: Cloudflare D1 (SQL) + KV (key‑value) as needed
-- **AI**: OpenAI GPT‑4 API + rules engine
-- **Payments**: Stripe
-- **Analytics**: PostHog or Plausible
-## Monetization
-1. 15–20% commission per booking  
-2. Freemium traveler features (solo‑safety insights, itinerary builder)  
-3. Host subscriptions for premium visibility & analytics  
-4. Partnerships with women‑focused brands & travel orgs
+- **Frontend**: Vite + React (TypeScript) deployed on Cloudflare Pages
+- **Backend / API**: Cloudflare Workers (Pages Functions) with KV storage
+- **AI**: OpenAI-compatible API + rule-based TrustScore
+- **Testing**: Vitest unit tests and Playwright smoke tests
+- **CI/CD**: GitHub Actions
+
+## Development Plan
+See [PLAN.md](./PLAN.md) for a step-by-step outline of how this repository will evolve into the full MVP.
 
 ## Initial Target Cities
 Lisbon • Barcelona • Bali • Mexico City • Marrakech • Chiang Mai • NYC • Tokyo
 
 ---
-*Empowering women to explore the world safely, authentically, and together.*# herwaxypoint
+*Empowering women to explore the world safely, authentically, and together.*


### PR DESCRIPTION
## Summary
- add high-level implementation plan for HerWaypoint MVP
- refresh README with tech stack and development plan reference
- ignore node_modules and build output

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a130c0b4a8832eab20be9fdd91a14e